### PR TITLE
fix: splitPath not working on windows

### DIFF
--- a/lib/path.dart
+++ b/lib/path.dart
@@ -90,7 +90,7 @@ _stringListFn splitPath = _exports.splitPath;
 _PathExports _factory(){
   var exports = new _PathExports();
 
-  var isWindows = Platform.operatingSystem == 'win32';
+  var isWindows = Platform.operatingSystem == 'win32' || Platform.operatingSystem=='windows';
   
   if (isWindows) {
     // Regex to split a windows path into three parts: [*, device, slash,


### PR DESCRIPTION
Platform.operatingSystem returns 'windows'. Maybe it was 'win32' in earlier Dart build.  
