### PR TITLE
fixes to run using dart 2.1.0-dev

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,8 @@ version: 0.1.3
 author: Demis Bellot <demis.bellot@gmail.com>
 description: Common node and js utils to help in porting of node.js and javascript libs to dart.
 homepage: https://github.com/dartist/node_shims/
+environment:
+  sdk: '>=1.20.1 <=2.1.0'
 dependencies:
   unittest: any
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dartist/node_shims/
 environment:
   sdk: '>=1.20.1 <=2.1.0'
 dependencies:
-  unittest: any
+  test: any
 
 #dependencies:
 #  unittest: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: node_shims
-version: 0.1.3
+version: 0.1.4
 author: Demis Bellot <demis.bellot@gmail.com>
 description: Common node and js utils to help in porting of node.js and javascript libs to dart.
 homepage: https://github.com/dartist/node_shims/


### PR DESCRIPTION
(Related to #5)

Few days ago, Dart version updated from `2.0.x`to `2.1.0-dev`.

This major updated broke a huge list of dart packages (do a google search and I'll see). 

Dart is strict restrictive about version. If you not declare environment `sdk` in `pubspec.yaml`, Dart will assume `2.0` by default.

I updated `pubspec.yaml` to fix that and changed dependency package, since `unittest` is deprecated and the author recommends to use `test` instead.

I hope it's okay for you.

Thanks!

PS: If you accept my pul request, pls update package in pub.dartlang.org too.